### PR TITLE
feat: automate weekly update PRs and harden CI security

### DIFF
--- a/.github/workflows/merge-weekly-flake-update.yml
+++ b/.github/workflows/merge-weekly-flake-update.yml
@@ -5,9 +5,7 @@ on:
     workflows: ["nix-ci"]
     types: [completed]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: merge-weekly-flake-update
@@ -18,6 +16,8 @@ jobs:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.repository.full_name == github.repository &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.head_branch == 'automation/weekly-flake-update'
     runs-on: ubuntu-latest
     steps:
@@ -42,8 +42,51 @@ jobs:
           fi
           echo "number=$pr_number" >> "$GITHUB_OUTPUT"
 
+      - name: Verify pull request provenance
+        env:
+          GH_TOKEN: ${{ secrets.PR_AUTOMATION_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          expected_owner="${GITHUB_REPOSITORY%/*}"
+          expected_repo="${GITHUB_REPOSITORY#*/}"
+          pr_json="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository)"
+          head_ref="$(jq -r '.headRefName' <<<"$pr_json")"
+          head_oid="$(jq -r '.headRefOid' <<<"$pr_json")"
+          base_ref="$(jq -r '.baseRefName' <<<"$pr_json")"
+          is_cross_repo="$(jq -r '.isCrossRepository' <<<"$pr_json")"
+          head_repo_name="$(jq -r '.headRepository.name // empty' <<<"$pr_json")"
+          head_repo_owner="$(jq -r '.headRepositoryOwner.login // empty' <<<"$pr_json")"
+
+          if [ "$head_ref" != "automation/weekly-flake-update" ]; then
+            echo "Refusing to merge PR #$PR_NUMBER: unexpected head ref '$head_ref'."
+            exit 1
+          fi
+
+          if [ "$base_ref" != "main" ]; then
+            echo "Refusing to merge PR #$PR_NUMBER: unexpected base ref '$base_ref'."
+            exit 1
+          fi
+
+          if [ "$is_cross_repo" != "false" ]; then
+            echo "Refusing to merge PR #$PR_NUMBER: cross-repository PRs are not eligible for privileged auto-merge."
+            exit 1
+          fi
+
+          if [ "$head_repo_owner" != "$expected_owner" ] || [ "$head_repo_name" != "$expected_repo" ]; then
+            echo "Refusing to merge PR #$PR_NUMBER: unexpected head repository '$head_repo_owner/$head_repo_name'."
+            exit 1
+          fi
+
+          if [ "$head_oid" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "Refusing to merge PR #$PR_NUMBER: head SHA '$head_oid' does not match validated workflow SHA '$EXPECTED_HEAD_SHA'."
+            exit 1
+          fi
+
       - name: Merge successful update PR
         env:
           GH_TOKEN: ${{ secrets.PR_AUTOMATION_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-        run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --squash --delete-branch
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --squash --delete-branch --match-head-commit "$HEAD_SHA"

--- a/.github/workflows/merge-weekly-flake-update.yml
+++ b/.github/workflows/merge-weekly-flake-update.yml
@@ -1,0 +1,49 @@
+name: merge-weekly-flake-update
+
+on:
+  workflow_run:
+    workflows: ["nix-ci"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: merge-weekly-flake-update
+  cancel-in-progress: false
+
+jobs:
+  merge-update-pr:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'automation/weekly-flake-update'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require PR automation token
+        env:
+          PR_AUTOMATION_TOKEN: ${{ secrets.PR_AUTOMATION_TOKEN }}
+        run: |
+          if [ -z "$PR_AUTOMATION_TOKEN" ]; then
+            echo "PR_AUTOMATION_TOKEN must be configured so the automation workflow can merge successful update PRs."
+            exit 1
+          fi
+
+      - name: Resolve pull request number
+        id: pr
+        env:
+          PULL_REQUESTS_JSON: ${{ toJson(github.event.workflow_run.pull_requests) }}
+        run: |
+          pr_number="$(jq -r '.[0].number // empty' <<<"$PULL_REQUESTS_JSON")"
+          if [ -z "$pr_number" ]; then
+            echo "No pull request was attached to the successful nix-ci workflow run."
+            exit 1
+          fi
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Merge successful update PR
+        env:
+          GH_TOKEN: ${{ secrets.PR_AUTOMATION_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --squash --delete-branch

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -13,10 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@da36cb69b1c3247ad7a1f931ebfd954a1105ef14 # v14
 
       - name: Show flake outputs
         run: nix flake show --no-write-lock-file
@@ -35,10 +38,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@da36cb69b1c3247ad7a1f931ebfd954a1105ef14 # v14
 
       - name: Run devShell unit tests
         run: nix develop -c bash tests/unit/devshell_unit.sh

--- a/.github/workflows/weekly-flake-update.yml
+++ b/.github/workflows/weekly-flake-update.yml
@@ -17,6 +17,15 @@ jobs:
   update-flake-lock:
     runs-on: ubuntu-latest
     steps:
+      - name: Require PR automation token
+        env:
+          PR_AUTOMATION_TOKEN: ${{ secrets.PR_AUTOMATION_TOKEN }}
+        run: |
+          if [ -z "$PR_AUTOMATION_TOKEN" ]; then
+            echo "PR_AUTOMATION_TOKEN must be configured so update PRs trigger pull_request CI."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -39,23 +48,12 @@ jobs:
         if: steps.lockfile.outputs.changed == 'true'
         run: git diff -- flake.lock
 
-      - name: Show flake outputs
-        if: steps.lockfile.outputs.changed == 'true'
-        run: nix flake show --no-write-lock-file
-
-      - name: Evaluate flake checks
-        if: steps.lockfile.outputs.changed == 'true'
-        run: nix flake check --no-build --no-write-lock-file
-
-      - name: Run devShell unit tests
-        if: steps.lockfile.outputs.changed == 'true'
-        run: nix develop -c bash tests/unit/devshell_unit.sh
-
       - name: Create pull request
+        id: create_pr
         if: steps.lockfile.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PR_AUTOMATION_TOKEN || github.token }}
+          token: ${{ secrets.PR_AUTOMATION_TOKEN }}
           commit-message: "chore: update flake.lock"
           title: "chore: weekly flake input update"
           body: |
@@ -63,16 +61,19 @@ jobs:
             - update pinned flake inputs with `nix flake update`
             - refresh `flake.lock`
 
-            ## Verification
-            - `nix flake show --no-write-lock-file`
-            - `nix flake check --no-build --no-write-lock-file`
-            - `nix develop -c bash tests/unit/devshell_unit.sh`
-
             ## Notes
             - This PR was created automatically by `.github/workflows/weekly-flake-update.yml`.
-            - Configure the optional `PR_AUTOMATION_TOKEN` secret if you want the generated PR to trigger the normal PR workflows.
+            - The repo's normal `nix-ci` pull request workflow will build and validate this PR.
+            - `.github/workflows/merge-weekly-flake-update.yml` will merge this PR only after `nix-ci` completes successfully.
           branch: automation/weekly-flake-update
           delete-branch: true
           labels: enhancement
           add-paths: |
             flake.lock
+
+      - name: Report PR update
+        if: steps.lockfile.outputs.changed == 'true'
+        run: |
+          echo "PR operation: ${{ steps.create_pr.outputs.pull-request-operation }}"
+          echo "PR number: ${{ steps.create_pr.outputs.pull-request-number }}"
+          echo "PR URL: ${{ steps.create_pr.outputs.pull-request-url }}"

--- a/.github/workflows/weekly-flake-update.yml
+++ b/.github/workflows/weekly-flake-update.yml
@@ -1,0 +1,78 @@
+name: weekly-flake-update
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: weekly-flake-update
+  cancel-in-progress: false
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Update flake lock
+        run: nix flake update
+
+      - name: Detect lockfile changes
+        id: lockfile
+        run: |
+          if git diff --quiet -- flake.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Show lockfile diff
+        if: steps.lockfile.outputs.changed == 'true'
+        run: git diff -- flake.lock
+
+      - name: Show flake outputs
+        if: steps.lockfile.outputs.changed == 'true'
+        run: nix flake show --no-write-lock-file
+
+      - name: Evaluate flake checks
+        if: steps.lockfile.outputs.changed == 'true'
+        run: nix flake check --no-build --no-write-lock-file
+
+      - name: Run devShell unit tests
+        if: steps.lockfile.outputs.changed == 'true'
+        run: nix develop -c bash tests/unit/devshell_unit.sh
+
+      - name: Create pull request
+        if: steps.lockfile.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PR_AUTOMATION_TOKEN || github.token }}
+          commit-message: "chore: update flake.lock"
+          title: "chore: weekly flake input update"
+          body: |
+            ## Summary
+            - update pinned flake inputs with `nix flake update`
+            - refresh `flake.lock`
+
+            ## Verification
+            - `nix flake show --no-write-lock-file`
+            - `nix flake check --no-build --no-write-lock-file`
+            - `nix develop -c bash tests/unit/devshell_unit.sh`
+
+            ## Notes
+            - This PR was created automatically by `.github/workflows/weekly-flake-update.yml`.
+            - Configure the optional `PR_AUTOMATION_TOKEN` secret if you want the generated PR to trigger the normal PR workflows.
+          branch: automation/weekly-flake-update
+          delete-branch: true
+          labels: enhancement
+          add-paths: |
+            flake.lock

--- a/.github/workflows/weekly-flake-update.yml
+++ b/.github/workflows/weekly-flake-update.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: weekly-flake-update
@@ -27,10 +26,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@da36cb69b1c3247ad7a1f931ebfd954a1105ef14 # v14
 
       - name: Update flake lock
         run: nix flake update
@@ -51,7 +53,7 @@ jobs:
       - name: Create pull request
         id: create_pr
         if: steps.lockfile.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.PR_AUTOMATION_TOKEN }}
           commit-message: "chore: update flake.lock"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repo includes a scheduled workflow at `.github/workflows/weekly-flake-updat
 
 The PR is then validated by the repo's normal `nix-ci` pull request workflow. If `nix-ci` succeeds for the automation branch, `.github/workflows/merge-weekly-flake-update.yml` merges the PR automatically. If `nix-ci` fails, the PR stays open for investigation and follow-up fixes.
 
-This flow requires a repository secret named `PR_AUTOMATION_TOKEN` with permission to write contents and pull requests. The automation uses that token both to create the PR and to merge it after successful CI so that the PR's `pull_request` workflows actually run.
+This flow requires a repository secret named `PR_AUTOMATION_TOKEN` with permission to write contents and pull requests. Prefer a GitHub App token or a fine-grained PAT scoped to this repository only. The automation uses that token both to create the PR and to merge it after successful CI so that the PR's `pull_request` workflows actually run.
 
 The normal PR validation for update PRs remains:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 A reproducible Nix flake for reverse engineering, firmware analysis, binary research, and AI-assisted workflows. 40+ tools organized into toggleable toolsets, packaged as a flake-parts module you can use standalone or import into your own flake.
 
+## Automated updates
+
+This repo includes a scheduled workflow at `.github/workflows/weekly-flake-update.yml` that runs every Monday at 08:00 UTC and opens a PR when `nix flake update` changes `flake.lock`.
+
+The workflow validates the updated lockfile before opening the PR by running:
+
+```bash
+nix flake show --no-write-lock-file
+nix flake check --no-build --no-write-lock-file
+nix develop -c bash tests/unit/devshell_unit.sh
+```
+
+If you want the generated PR to trigger the repo's normal `push` and `pull_request` workflows, add an optional `PR_AUTOMATION_TOKEN` repository secret with permission to write contents and pull requests. Without that secret, the workflow still opens or updates the PR using the default `GITHUB_TOKEN`, but GitHub suppresses follow-on workflow runs created by that token.
+
 ## Quick start
 
 ### 1. Enter the environment

--- a/README.md
+++ b/README.md
@@ -6,17 +6,19 @@ A reproducible Nix flake for reverse engineering, firmware analysis, binary rese
 
 ## Automated updates
 
-This repo includes a scheduled workflow at `.github/workflows/weekly-flake-update.yml` that runs every Monday at 08:00 UTC and opens a PR when `nix flake update` changes `flake.lock`.
+This repo includes a scheduled workflow at `.github/workflows/weekly-flake-update.yml` that runs every Monday at 08:00 UTC and opens or refreshes a PR when `nix flake update` changes `flake.lock`.
 
-The workflow validates the updated lockfile before opening the PR by running:
+The PR is then validated by the repo's normal `nix-ci` pull request workflow. If `nix-ci` succeeds for the automation branch, `.github/workflows/merge-weekly-flake-update.yml` merges the PR automatically. If `nix-ci` fails, the PR stays open for investigation and follow-up fixes.
+
+This flow requires a repository secret named `PR_AUTOMATION_TOKEN` with permission to write contents and pull requests. The automation uses that token both to create the PR and to merge it after successful CI so that the PR's `pull_request` workflows actually run.
+
+The normal PR validation for update PRs remains:
 
 ```bash
 nix flake show --no-write-lock-file
 nix flake check --no-build --no-write-lock-file
 nix develop -c bash tests/unit/devshell_unit.sh
 ```
-
-If you want the generated PR to trigger the repo's normal `push` and `pull_request` workflows, add an optional `PR_AUTOMATION_TOKEN` repository secret with permission to write contents and pull requests. Without that secret, the workflow still opens or updates the PR using the default `GITHUB_TOKEN`, but GitHub suppresses follow-on workflow runs created by that token.
 
 ## Quick start
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,3 @@
+# Lessons
+
+- No project-specific lessons recorded yet.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,3 +1,3 @@
 # Lessons
 
-- No project-specific lessons recorded yet.
+- When automating dependency update PRs, separate "create the PR" from "validate and merge the PR". Do not gate PR creation on pre-PR checks if the requirement is to leave failing update PRs open for follow-up fixes.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,7 +5,7 @@
 - [x] Implement the GitHub Actions workflow for scheduled updates.
 - [x] Document the automation in the repository.
 - [x] Validate workflow syntax and relevant repo checks.
-- [ ] Commit the change set and open a pull request.
+- [x] Commit the change set and open a pull request.
 
 ## Review
 
@@ -15,3 +15,4 @@
 - `nix flake check --no-build --no-write-lock-file`: passed.
 - `nix run nixpkgs#actionlint -- .github/workflows/weekly-flake-update.yml`: passed.
 - `nix develop -c bash tests/unit/devshell_unit.sh`: fails on both this branch and `origin/main` because `sleuthkit` is missing from the devShell PATH.
+- Opened PR `#2`: `feat: automate weekly flake update PRs`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,7 @@
 - [x] Implement post-CI merge behavior for successful automation PRs.
 - [x] Document the PR-first build-and-merge behavior in the repository.
 - [x] Validate workflow syntax and relevant repo checks.
-- [ ] Commit the updated change set and refresh the pull request.
+- [x] Commit the updated change set and refresh the pull request.
 
 ## Review
 
@@ -17,3 +17,4 @@
 - `nix flake show --no-write-lock-file`: passed.
 - `nix flake check --no-build --no-write-lock-file`: passed.
 - `nix develop -c bash tests/unit/devshell_unit.sh`: fails on this branch because `sleuthkit` is missing from the devShell PATH, so automation PRs will stay open until that baseline CI issue is fixed.
+- Updated PR `#2` with the PR-first build-and-merge workflow changes.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -18,3 +18,17 @@
 - `nix flake check --no-build --no-write-lock-file`: passed.
 - `nix develop -c bash tests/unit/devshell_unit.sh`: fails on this branch because `sleuthkit` is missing from the devShell PATH, so automation PRs will stay open until that baseline CI issue is fixed.
 - Updated PR `#2` with the PR-first build-and-merge workflow changes.
+
+## Follow-up: Fix sleuthkit devShell test
+
+- [x] Trace the failing `sleuthkit` assertion to the forensics toolset.
+- [x] Patch the unit test or shell composition at the narrowest correct point.
+- [x] Re-run the devShell unit test and supporting repo checks.
+- [ ] Commit and push the fix to PR `#2`.
+
+### Follow-up Review
+
+- Updated `tests/unit/devshell_unit.sh` to assert real Sleuth Kit executables (`fls` and `icat`) instead of a nonexistent `sleuthkit` wrapper command.
+- `nix develop -c bash tests/unit/devshell_unit.sh`: passed (`46 assertions`).
+- `nix flake show --no-write-lock-file`: passed.
+- `nix flake check --no-build --no-write-lock-file`: passed.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,17 @@
+# Task Plan
+
+- [x] Review existing CI workflows and repo context.
+- [x] Design a weekly automation path that updates pinned flake dependencies via PR.
+- [x] Implement the GitHub Actions workflow for scheduled updates.
+- [x] Document the automation in the repository.
+- [x] Validate workflow syntax and relevant repo checks.
+- [ ] Commit the change set and open a pull request.
+
+## Review
+
+- Added `.github/workflows/weekly-flake-update.yml` to run weekly and on manual dispatch.
+- Documented the automation and token caveat in `README.md`.
+- `nix flake show --no-write-lock-file`: passed.
+- `nix flake check --no-build --no-write-lock-file`: passed.
+- `nix run nixpkgs#actionlint -- .github/workflows/weekly-flake-update.yml`: passed.
+- `nix develop -c bash tests/unit/devshell_unit.sh`: fails on both this branch and `origin/main` because `sleuthkit` is missing from the devShell PATH.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -24,7 +24,7 @@
 - [x] Trace the failing `sleuthkit` assertion to the forensics toolset.
 - [x] Patch the unit test or shell composition at the narrowest correct point.
 - [x] Re-run the devShell unit test and supporting repo checks.
-- [ ] Commit and push the fix to PR `#2`.
+- [x] Commit and push the fix to PR `#2`.
 
 ### Follow-up Review
 
@@ -32,3 +32,4 @@
 - `nix develop -c bash tests/unit/devshell_unit.sh`: passed (`46 assertions`).
 - `nix flake show --no-write-lock-file`: passed.
 - `nix flake check --no-build --no-write-lock-file`: passed.
+- Pushed the fix to PR `#2` and refreshed the PR description to remove the stale baseline-failure note.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -40,7 +40,7 @@
 - [x] Pin all third-party actions to immutable SHAs and tighten checkout behavior.
 - [x] Reduce default workflow token permissions and strengthen privileged merge provenance checks.
 - [x] Apply repository-level GitHub Actions restrictions that match the pinned workflow set.
-- [ ] Re-run local workflow validation and update PR `#2`.
+- [x] Re-run local workflow validation and update PR `#2`.
 
 ### Security Hardening Review
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,17 +2,18 @@
 
 - [x] Review existing CI workflows and repo context.
 - [x] Design a weekly automation path that updates pinned flake dependencies via PR.
-- [x] Implement the GitHub Actions workflow for scheduled updates.
-- [x] Document the automation in the repository.
+- [x] Implement the weekly PR automation workflow.
+- [x] Implement post-CI merge behavior for successful automation PRs.
+- [x] Document the PR-first build-and-merge behavior in the repository.
 - [x] Validate workflow syntax and relevant repo checks.
-- [x] Commit the change set and open a pull request.
+- [ ] Commit the updated change set and refresh the pull request.
 
 ## Review
 
-- Added `.github/workflows/weekly-flake-update.yml` to run weekly and on manual dispatch.
-- Documented the automation and token caveat in `README.md`.
+- Updated `.github/workflows/weekly-flake-update.yml` so lockfile changes always create or refresh the automation PR instead of gating PR creation on pre-PR checks.
+- Added `.github/workflows/merge-weekly-flake-update.yml` to merge the automation PR only after `nix-ci` completes successfully for `automation/weekly-flake-update`.
+- Documented the required `PR_AUTOMATION_TOKEN` secret and the PR-first build-and-merge flow in `README.md`.
+- `nix run nixpkgs#actionlint -- .github/workflows/nix-ci.yml .github/workflows/weekly-flake-update.yml .github/workflows/merge-weekly-flake-update.yml`: passed.
 - `nix flake show --no-write-lock-file`: passed.
 - `nix flake check --no-build --no-write-lock-file`: passed.
-- `nix run nixpkgs#actionlint -- .github/workflows/weekly-flake-update.yml`: passed.
-- `nix develop -c bash tests/unit/devshell_unit.sh`: fails on both this branch and `origin/main` because `sleuthkit` is missing from the devShell PATH.
-- Opened PR `#2`: `feat: automate weekly flake update PRs`.
+- `nix develop -c bash tests/unit/devshell_unit.sh`: fails on this branch because `sleuthkit` is missing from the devShell PATH, so automation PRs will stay open until that baseline CI issue is fixed.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -33,3 +33,24 @@
 - `nix flake show --no-write-lock-file`: passed.
 - `nix flake check --no-build --no-write-lock-file`: passed.
 - Pushed the fix to PR `#2` and refreshed the PR description to remove the stale baseline-failure note.
+
+## Follow-up: Harden GitHub Actions security
+
+- [x] Audit workflow files and repository Actions settings for code-injection and token-exposure risks.
+- [x] Pin all third-party actions to immutable SHAs and tighten checkout behavior.
+- [x] Reduce default workflow token permissions and strengthen privileged merge provenance checks.
+- [x] Apply repository-level GitHub Actions restrictions that match the pinned workflow set.
+- [ ] Re-run local workflow validation and update PR `#2`.
+
+### Security Hardening Review
+
+- Pinned `actions/checkout`, `DeterminateSystems/nix-installer-action`, and `peter-evans/create-pull-request` to full commit SHAs.
+- Set `persist-credentials: false` and `fetch-depth: 1` on all checkout steps.
+- Reduced `GITHUB_TOKEN` permissions in the write-capable workflows so writes happen through the scoped `PR_AUTOMATION_TOKEN` only.
+- Hardened `.github/workflows/merge-weekly-flake-update.yml` to verify base branch, head branch, head repository, cross-repo status, and exact validated head SHA before merge.
+- Updated repository Actions settings with `allowed_actions=selected`, `sha_pinning_required=true`, and an explicit allowlist for `DeterminateSystems/nix-installer-action@*` and `peter-evans/create-pull-request@*`.
+- Updated fork PR workflow approval policy to `all_external_contributors`.
+- `nix run nixpkgs#actionlint -- .github/workflows/nix-ci.yml .github/workflows/weekly-flake-update.yml .github/workflows/merge-weekly-flake-update.yml`: passed.
+- `nix flake show --no-write-lock-file`: passed.
+- `nix flake check --no-build --no-write-lock-file`: passed.
+- `nix develop -c bash tests/unit/devshell_unit.sh`: passed (`46 assertions`).

--- a/tests/unit/devshell_unit.sh
+++ b/tests/unit/devshell_unit.sh
@@ -116,7 +116,9 @@ assert_cmd afl-fuzz
 # ---------------------------------------------------------------------------
 assert_cmd binwalk
 assert_cmd foremost
-assert_cmd sleuthkit
+# Sleuth Kit ships a family of binaries rather than a `sleuthkit` command.
+assert_cmd fls
+assert_cmd icat
 
 # ---------------------------------------------------------------------------
 # Section: Crypto toolset


### PR DESCRIPTION
## Summary
- add scheduled automation to open or refresh a weekly `flake.lock` PR and merge it only after `nix-ci` succeeds
- harden GitHub Actions by pinning actions to immutable SHAs, disabling checkout credential persistence, reducing default workflow token permissions, and tightening the privileged merge provenance checks
- fix the devShell unit test to validate real Sleuth Kit binaries instead of a nonexistent `sleuthkit` command
- expand the shell with `apktool`, `bpftrace`, `frida-tools`, `mitmproxy`, `volatility3`, `wireshark`, and `yara-x`
- update the README and unit tests to reflect the expanded toolset

Closes #1.

## Verification
- `nix develop -c bash tests/unit/devshell_unit.sh`
- `nix flake show --no-write-lock-file`
- `nix flake check --no-build --no-write-lock-file`
- `nix run nixpkgs#actionlint -- .github/workflows/nix-ci.yml .github/workflows/weekly-flake-update.yml .github/workflows/merge-weekly-flake-update.yml`

## GitHub Settings Updated
- Actions policy set to `selected` with `sha_pinning_required=true`
- Allowed actions restricted to GitHub-owned actions plus `DeterminateSystems/nix-installer-action@*` and `peter-evans/create-pull-request@*`
- Fork PR workflow approval policy set to `all_external_contributors`