### PR TITLE
feat: add dynamic and forensics tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The module provides `devShells.default` per system. It also exposes `reenvToolse
 | retdec | LLVM-based machine-code decompiler |
 | Cutter | GUI front-end for Rizin/radare |
 | Binary Ninja Free | Secondary disassembler/decompiler for cross-checking |
+| Apktool | Android APK decode/rebuild workflow for manifests, resources, and smali |
 | JADX | Android DEX/APK decompiler |
 | Krakatau2 | Java bytecode disassembly and decompilation |
 | BinDiff (x86_64 only) | Binary diffing to compare functions between builds |
@@ -155,6 +156,8 @@ The module provides `devShells.default` per system. It also exposes `reenvToolse
 | Tool | Description |
 |---|---|
 | gdb | GNU debugger |
+| bpftrace | eBPF tracing for kernel and userland behavior |
+| Frida tools | Dynamic instrumentation and runtime API hooking |
 | GEF | GDB enhancement framework for exploit/RE workflows |
 | lldb | LLVM debugger |
 | rr | Record/replay debugger for deterministic analysis |
@@ -176,11 +179,15 @@ The module provides `devShells.default` per system. It also exposes `reenvToolse
 |---|---|
 | binwalk | Firmware/image extraction and signature scanning |
 | foremost | File carving from raw images |
+| mitmproxy | Interactive interception and replay for HTTP(S) traffic |
 | squashfsTools | SquashFS firmware filesystem extraction |
 | jefferson | JFFS2 filesystem extraction |
 | ubi_reader | UBI/UBIFS parsing for embedded firmware |
 | scalpel | File carving and recovery |
 | sleuthkit | Filesystem forensics (`fls`, `icat`, etc.) |
+| Volatility 3 | Memory forensics framework for Windows, Linux, and macOS images |
+| Wireshark / TShark | GUI and CLI packet inspection for protocol analysis |
+| YARA-X (`yr`) | Rule-based scanning and triage for firmware, malware, and extracted filesystems |
 | p7zip | 7z archive extraction |
 | rar | RAR archive handling |
 

--- a/modules/toolsets/debugging.nix
+++ b/modules/toolsets/debugging.nix
@@ -1,4 +1,6 @@
 {pkgs}: [
+  pkgs.bpftrace
+  pkgs."frida-tools"
   pkgs.gdb
   pkgs.gef
   pkgs.lldb

--- a/modules/toolsets/forensics.nix
+++ b/modules/toolsets/forensics.nix
@@ -1,11 +1,15 @@
 {pkgs}: [
   pkgs.binwalk
   pkgs.foremost
+  pkgs.mitmproxy
+  pkgs.volatility3
   pkgs.squashfsTools
   pkgs.jefferson
   pkgs.ubi_reader
   pkgs.scalpel
   pkgs.sleuthkit
+  pkgs.wireshark
+  pkgs."yara-x"
   pkgs.p7zip
   pkgs.rar
 ]

--- a/modules/toolsets/reversing.nix
+++ b/modules/toolsets/reversing.nix
@@ -30,6 +30,7 @@ in {
 
   packages =
     [
+      pkgs.apktool
       ghidraWithExtensions
       rizinWithPlugins
       pkgs.radare2

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,3 +1,4 @@
 # Lessons
 
 - When automating dependency update PRs, separate "create the PR" from "validate and merge the PR". Do not gate PR creation on pre-PR checks if the requirement is to leave failing update PRs open for follow-up fixes.
+- After a PR is merged, do not continue landing new work on the same branch. Check the merge state first, then start a fresh branch from `main` for any follow-up changes that still need review.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -59,7 +59,7 @@
 
 - [x] Map the requested tools to existing toolset categories and confirm package/command names.
 - [x] Add the requested tools to Nix toolsets and update docs/tests.
-- [ ] Re-run repo validation and open a fresh PR from `main`.
+- [x] Re-run repo validation and open a fresh PR from `main`.
 
 ### Tool Addition Review
 
@@ -71,3 +71,4 @@
 - `nix flake show --no-write-lock-file`: passed.
 - `nix flake check --no-build --no-write-lock-file`: passed.
 - Replaying this tool-addition change on a fresh branch because the earlier branch had already been merged.
+- Opened follow-up PR `#3` from `feat/add-re-tools`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -54,3 +54,20 @@
 - `nix flake show --no-write-lock-file`: passed.
 - `nix flake check --no-build --no-write-lock-file`: passed.
 - `nix develop -c bash tests/unit/devshell_unit.sh`: passed (`46 assertions`).
+
+## Follow-up: Add Recommended RE Tools
+
+- [x] Map the requested tools to existing toolset categories and confirm package/command names.
+- [x] Add the requested tools to Nix toolsets and update docs/tests.
+- [ ] Re-run repo validation and open a fresh PR from `main`.
+
+### Tool Addition Review
+
+- Added `apktool` to the reversing toolset.
+- Added `bpftrace` and `frida-tools` to the debugging toolset.
+- Added `mitmproxy`, `volatility3`, `wireshark`, and `yara-x` to the forensics toolset.
+- Updated `README.md` and `tests/unit/devshell_unit.sh` to document and validate the new commands.
+- `nix develop -c bash tests/unit/devshell_unit.sh`: passed (`53 assertions`).
+- `nix flake show --no-write-lock-file`: passed.
+- `nix flake check --no-build --no-write-lock-file`: passed.
+- Replaying this tool-addition change on a fresh branch because the earlier branch had already been merged.

--- a/tests/unit/devshell_unit.sh
+++ b/tests/unit/devshell_unit.sh
@@ -87,6 +87,7 @@ assert_symlink() {
 # ---------------------------------------------------------------------------
 # Section: Core reversing tools (reversing toolset)
 # ---------------------------------------------------------------------------
+assert_cmd apktool
 assert_cmd ghidra
 assert_cmd rizin
 assert_cmd r2
@@ -103,6 +104,8 @@ fi
 # ---------------------------------------------------------------------------
 # Section: Debugging toolset
 # ---------------------------------------------------------------------------
+assert_cmd bpftrace
+assert_cmd frida
 assert_cmd gdb
 assert_cmd strace
 
@@ -116,9 +119,13 @@ assert_cmd afl-fuzz
 # ---------------------------------------------------------------------------
 assert_cmd binwalk
 assert_cmd foremost
+assert_cmd mitmproxy
 # Sleuth Kit ships a family of binaries rather than a `sleuthkit` command.
 assert_cmd fls
 assert_cmd icat
+assert_cmd tshark
+assert_cmd vol
+assert_cmd yr
 
 # ---------------------------------------------------------------------------
 # Section: Crypto toolset


### PR DESCRIPTION
## Summary
- add `apktool`, `bpftrace`, `frida-tools`, `mitmproxy`, `volatility3`, `wireshark`, and `yara-x` to the shell toolsets
- update the README and shell unit tests to document and validate the new commands
- record the workflow lesson to avoid continuing work on a branch after its PR has already been merged

## Verification
- `nix develop -c bash tests/unit/devshell_unit.sh`
- `nix flake show --no-write-lock-file`
- `nix flake check --no-build --no-write-lock-file`

## Context
This is a follow-up PR because the tool-addition work was originally committed on a branch after PR #2 had already been merged.