### PR TITLE
docs: move automated updates to collapsible footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,6 @@
 
 A reproducible Nix flake for reverse engineering, firmware analysis, binary research, and AI-assisted workflows. 40+ tools organized into toggleable toolsets, packaged as a flake-parts module you can use standalone or import into your own flake.
 
-## Automated updates
-
-This repo includes a scheduled workflow at `.github/workflows/weekly-flake-update.yml` that runs every Monday at 08:00 UTC and opens or refreshes a PR when `nix flake update` changes `flake.lock`.
-
-The PR is then validated by the repo's normal `nix-ci` pull request workflow. If `nix-ci` succeeds for the automation branch, `.github/workflows/merge-weekly-flake-update.yml` merges the PR automatically. If `nix-ci` fails, the PR stays open for investigation and follow-up fixes.
-
-This flow requires a repository secret named `PR_AUTOMATION_TOKEN` with permission to write contents and pull requests. Prefer a GitHub App token or a fine-grained PAT scoped to this repository only. The automation uses that token both to create the PR and to merge it after successful CI so that the PR's `pull_request` workflows actually run.
-
-The normal PR validation for update PRs remains:
-
-```bash
-nix flake show --no-write-lock-file
-nix flake check --no-build --no-write-lock-file
-nix develop -c bash tests/unit/devshell_unit.sh
-```
-
 ## Quick start
 
 ### 1. Enter the environment
@@ -304,5 +288,24 @@ nix develop -c bash tests/unit/devshell_unit.sh
 - Use descriptive commit messages.
 - Document behavior changes in `README.md` when user-facing.
 - Do not commit local runtime artifacts (for example `.direnv/` and `.mcp.json`).
+
+</details>
+
+<details>
+<summary>Automated updates</summary>
+
+This repo includes a scheduled workflow at `.github/workflows/weekly-flake-update.yml` that runs every Monday at 08:00 UTC and opens or refreshes a PR when `nix flake update` changes `flake.lock`.
+
+The PR is then validated by the repo's normal `nix-ci` pull request workflow. If `nix-ci` succeeds for the automation branch, `.github/workflows/merge-weekly-flake-update.yml` merges the PR automatically. If `nix-ci` fails, the PR stays open for investigation and follow-up fixes.
+
+This flow requires a repository secret named `PR_AUTOMATION_TOKEN` with permission to write contents and pull requests. Prefer a GitHub App token or a fine-grained PAT scoped to this repository only. The automation uses that token both to create the PR and to merge it after successful CI so that the PR's `pull_request` workflows actually run.
+
+The normal PR validation for update PRs remains:
+
+```bash
+nix flake show --no-write-lock-file
+nix flake check --no-build --no-write-lock-file
+nix develop -c bash tests/unit/devshell_unit.sh
+```
 
 </details>

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2,3 +2,4 @@
 
 - When automating dependency update PRs, separate "create the PR" from "validate and merge the PR". Do not gate PR creation on pre-PR checks if the requirement is to leave failing update PRs open for follow-up fixes.
 - After a PR is merged, do not continue landing new work on the same branch. Check the merge state first, then start a fresh branch from `main` for any follow-up changes that still need review.
+- Before pushing a follow-up change, re-fetch and confirm whether the target PR has already merged. If it has, open a new branch and PR immediately instead of assuming the old review thread is still active.


### PR DESCRIPTION
## Summary
- move the `Automated updates` README section to the bottom of the file
- render it as a collapsible `<details>` section instead of a top-level always-open section
- record the branch-state lesson from the merge timing correction

## Verification
- verified the README layout locally by reading the top and bottom sections after the move

## Context
PR #3 had already been merged before the footer move was pushed, so this is a small follow-up PR for that docs change.